### PR TITLE
Remove Incorrect h-property

### DIFF
--- a/templates/default/entity/Food.tpl.php
+++ b/templates/default/entity/Food.tpl.php
@@ -40,7 +40,7 @@
     ?>
             
             <div class="e-content">
-                <?= "#".$vars['object']->getCategory-id() ?>"></i>
+                <h2 class="p-name<?= $vars['object']->getCategory() ?>">
                 <?= $this->__(['value' => $vars['object']->body, 'object' => $vars['object']])->draw('forms/output/richtext'); ?>
             </div>
             

--- a/templates/default/entity/Food.tpl.php
+++ b/templates/default/entity/Food.tpl.php
@@ -4,7 +4,7 @@
 
         if (\Idno\Core\site()->template()->getTemplateType() == 'default') {
             ?>
-            <h2 class="p-name h-<?= $vars['object']->getCategory() ?>">
+            <h2 class="p-name">
                 <a class="u-url" href="<?= $vars['object']->getDisplayURL() ?>">
                    <i class="fa <?= $vars['object']->getCategoryIcon() ?>"></i>
                     <?= htmlentities(strip_tags($vars['object']->getTitle()), ENT_QUOTES, 'UTF-8'); ?>
@@ -40,7 +40,7 @@
     ?>
             
             <div class="e-content">
-                
+                #<?= $vars['object']->getCategory-id() ?>"></i>
                 <?= $this->__(['value' => $vars['object']->body, 'object' => $vars['object']])->draw('forms/output/richtext'); ?>
             </div>
             

--- a/templates/default/entity/Food.tpl.php
+++ b/templates/default/entity/Food.tpl.php
@@ -40,7 +40,7 @@
     ?>
             
             <div class="e-content">
-                #<?= $vars['object']->getCategory-id() ?>"></i>
+                <?= "#".$vars['object']->getCategory-id() ?>"></i>
                 <?= $this->__(['value' => $vars['object']->body, 'object' => $vars['object']])->draw('forms/output/richtext'); ?>
             </div>
             


### PR DESCRIPTION
Currently, the drop down menu adds the pref fix h- to the h2 element which is incorrect.

I do want to delineate between ate, drank, drank-coffee, drank-beer I tried to add the category-id to the e-content with a pound symbol in front to make a hashtag and thus add the p-category and ability to follow the rss or mf2 feed for "ate, drank, drank-coffee, or drank-beer"

If I am doing line 43 wrong either delete or fix but push line 7. The one thing I noticed was in the edit template category was lowercased but it capitalized in getCategory-id so I am sure I am doing something wrong. 